### PR TITLE
Implement PDI activity data loader

### DIFF
--- a/src/pdi_scheduler/loader.py
+++ b/src/pdi_scheduler/loader.py
@@ -1,0 +1,60 @@
+"""Load PDI activity data from the Excel export.
+
+The export has a fixed 17-column schema. This module reads the file, validates
+the columns, and returns a typed pandas DataFrame.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+EXPECTED_COLUMNS = [
+    "No.", "Activity Type", "Activity Status", "VPC", "Handling Unit",
+    "Additional ID", "Creation Time", "First Assignment Time", "Start Time",
+    "Latest End", "Maximal Duration", "Approx. End", "Delay", "Delay Level",
+    "Resource", "Planned Start Time", "Planned End Time",
+]
+
+DATETIME_COLUMNS = [
+    "Creation Time", "First Assignment Time", "Start Time",
+    "Latest End", "Approx. End", "Planned Start Time", "Planned End Time",
+]
+
+
+def load_activities(path: str | Path) -> pd.DataFrame:
+    """Read a PDI activity export and return a typed DataFrame.
+
+    Args:
+        path: Path to the .xlsx export file.
+
+    Returns:
+        DataFrame with all 17 expected columns, dates parsed as datetime64,
+        and VPC parsed as bool.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+        ValueError: If the file is missing any of the 17 expected columns.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"PDI export not found: {path}")
+
+    df = pd.read_excel(path, sheet_name="Export")
+
+    missing = set(EXPECTED_COLUMNS) - set(df.columns)
+    if missing:
+        raise ValueError(
+            f"Export is missing expected columns: {sorted(missing)}"
+        )
+
+    # Coerce date columns to datetime — openpyxl usually gets this right,
+    # but we force it to guarantee the contract with downstream modules.
+    for col in DATETIME_COLUMNS:
+        df[col] = pd.to_datetime(df[col], errors="coerce")
+
+    # VPC should always be boolean
+    df["VPC"] = df["VPC"].astype(bool)
+
+    # Preserve canonical column order
+    return df[EXPECTED_COLUMNS]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -8,20 +8,14 @@ import pytest
 
 from pdi_scheduler.loader import load_activities
 
+from pdi_scheduler.loader import (
+    DATETIME_COLUMNS,
+    EXPECTED_COLUMNS,
+    load_activities,
+)
+
 # Path to the committed synthetic dataset. Tests assume it has been generated.
 SAMPLE_PATH = Path(__file__).resolve().parent.parent / "data" / "sample_pdi_export.xlsx"
-
-EXPECTED_COLUMNS = [
-    "No.", "Activity Type", "Activity Status", "VPC", "Handling Unit",
-    "Additional ID", "Creation Time", "First Assignment Time", "Start Time",
-    "Latest End", "Maximal Duration", "Approx. End", "Delay", "Delay Level",
-    "Resource", "Planned Start Time", "Planned End Time",
-]
-
-DATETIME_COLUMNS = [
-    "Creation Time", "First Assignment Time", "Start Time",
-    "Latest End", "Approx. End", "Planned Start Time", "Planned End Time",
-]
 
 
 class TestLoadActivities:

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,74 @@
+"""Tests for pdi_scheduler.loader — the Excel data loader."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+import pytest
+
+from pdi_scheduler.loader import load_activities
+
+# Path to the committed synthetic dataset. Tests assume it has been generated.
+SAMPLE_PATH = Path(__file__).resolve().parent.parent / "data" / "sample_pdi_export.xlsx"
+
+EXPECTED_COLUMNS = [
+    "No.", "Activity Type", "Activity Status", "VPC", "Handling Unit",
+    "Additional ID", "Creation Time", "First Assignment Time", "Start Time",
+    "Latest End", "Maximal Duration", "Approx. End", "Delay", "Delay Level",
+    "Resource", "Planned Start Time", "Planned End Time",
+]
+
+DATETIME_COLUMNS = [
+    "Creation Time", "First Assignment Time", "Start Time",
+    "Latest End", "Approx. End", "Planned Start Time", "Planned End Time",
+]
+
+
+class TestLoadActivities:
+    """Tests for the load_activities function."""
+
+    def test_returns_dataframe(self):
+        """Happy path: loading a valid Excel returns a DataFrame."""
+        df = load_activities(SAMPLE_PATH)
+        assert isinstance(df, pd.DataFrame)
+
+    def test_has_all_expected_columns(self):
+        """Loader preserves all 17 columns from the export."""
+        df = load_activities(SAMPLE_PATH)
+        assert list(df.columns) == EXPECTED_COLUMNS
+
+    def test_has_expected_row_count(self):
+        """Loader reads every row of the synthetic file."""
+        df = load_activities(SAMPLE_PATH)
+        # Synthetic data: 150 vehicles, ~2,500 activities
+        assert len(df) > 2_000
+        assert len(df) < 5_000
+
+    def test_datetime_columns_are_parsed(self):
+        """Date columns come back as pandas datetime64, not strings."""
+        df = load_activities(SAMPLE_PATH)
+        for col in DATETIME_COLUMNS:
+            assert pd.api.types.is_datetime64_any_dtype(df[col]), (
+                f"Column {col!r} is not datetime; got {df[col].dtype}"
+            )
+
+    def test_vpc_column_is_boolean(self):
+        """VPC column is parsed as bool, not string or int."""
+        df = load_activities(SAMPLE_PATH)
+        assert pd.api.types.is_bool_dtype(df["VPC"])
+
+    def test_raises_file_not_found(self, tmp_path):
+        """Non-existent path raises FileNotFoundError with a helpful message."""
+        missing = tmp_path / "does_not_exist.xlsx"
+        with pytest.raises(FileNotFoundError, match="does_not_exist.xlsx"):
+            load_activities(missing)
+
+    def test_raises_value_error_on_missing_columns(self, tmp_path):
+        """An Excel file missing required columns raises ValueError."""
+        bad_path = tmp_path / "bad.xlsx"
+        # Create an Excel with the wrong shape
+        pd.DataFrame({"some": [1], "other": [2], "columns": [3]}).to_excel(
+            bad_path, index=False, sheet_name="Export"
+        )
+        with pytest.raises(ValueError, match="missing expected columns"):
+            load_activities(bad_path)


### PR DESCRIPTION
## Summary
First piece of real business logic. Loads the PDI Excel export, validates its schema, and returns a typed DataFrame ready for downstream modules.

## TDD narrative
Built test-first. The Red → Green → Refactor cycle is visible in the commit history:

1. 🔴 **Red** — `Add failing tests for data loader (Ticket #16 — Red)` — 7 tests committed before any production code. pytest reported `ModuleNotFoundError` (correct and expected).
2. 🟢 **Green** — `Implement data loader to make tests pass (Ticket #16 — Green)` — minimum implementation in `src/pdi_scheduler/loader.py`. All 7 tests pass.
3. ♻️ **Refactor** — `Refactor test module to import shared constants (Ticket #16 — Refactor)` — removed duplication between test and module.
4. 🧹 **Lint** — `Fix lint issues…` — ruff caught a real bug (F811 duplicate import) that would have made it to main without static analysis.

## Test coverage