### PR TITLE
Add GitHub Actions CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,41 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Lint with ruff
+        run: ruff check .
+
+      - name: Run tests with coverage
+        run: |
+          pytest --cov=src/pdi_scheduler --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml
+          retention-days: 7

--- a/README.md
+++ b/README.md
@@ -1,2 +1,7 @@
+[![CI](https://github.com/nicoflas123-ui/pdi-scheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/nicoflas123-ui/pdi-scheduler/actions/workflows/ci.yml)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
+
 # pdi-scheduler
 A workflow prioritisation dashboard for PDI (Pre-Delivery Inspection) operations, highlighting at-risk vehicles based on deadlines, duration estimates, and team capacity.


### PR DESCRIPTION
## Summary
Adds the CI pipeline. Every push to main and every PR now automatically runs `ruff check` and the full pytest suite with coverage on Ubuntu + Python 3.11.

## What changed
- `.github/workflows/ci.yml` — workflow file
- `README.md` — added CI status, Python version, and license badges

## What this means going forward
- A red CI on a PR blocks merging until fixed
- Coverage reports are uploaded as artifacts on every run, retained for 7 days
- The trailing-newline issues we fixed manually in PRs #33 and #40 would now fail CI before merging — exactly the kind of pre-commit discipline we noted in earlier retrospectives

## Verification
The workflow will run automatically against this PR. The PR can only merge if CI is green — proves the pipeline works end-to-end.

Closes #26